### PR TITLE
Add ability to persist snippets under home directory

### DIFF
--- a/src/delete.js
+++ b/src/delete.js
@@ -1,20 +1,13 @@
 module.exports = (pluginContext) => {
-  const { cwd, console } = pluginContext
-  const snippets = require('./lib/snippets')(cwd, console)
-
   return (key, env = {}) => {
+    const { console } = pluginContext
+    const snippets = require('./lib/snippets')(console, env)
     return new Promise((resolve, reject) => {
       const value = snippets.search(key)
-      if (!value) {
-        return Promise.resolve()
-      } else {
-        resolve([{
-          id: key,
-          title: `Delete snippet called "${key}"`,
-          value: key,
-        }])
-      }
+      const deleteConfirm = [{
+        id: key, title: `Delete snippet called "${key}"`, value: key,
+      }]
+      resolve(value ? deleteConfirm : [])
     })
   }
 }
-

--- a/src/deleteSnippet.js
+++ b/src/deleteSnippet.js
@@ -1,8 +1,7 @@
 module.exports = (pluginContext) => {
-  const { cwd, console } = pluginContext
-  const snippets = require('./lib/snippets')(cwd, console)
-
   return (name, env = {}) => {
+    const { console } = pluginContext
+    const snippets = require('./lib/snippets')(console, env)
     snippets.delete(name)
     return Promise.resolve()
   }

--- a/src/lib/snippets.js
+++ b/src/lib/snippets.js
@@ -1,14 +1,17 @@
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 const fuzzy = require('fuzzyfind')
 const { htmlEncode } = require('js-htmlencode')
 
 class Snippets {
-  constructor (dir, console) {
-    this.dir = dir
+  constructor (console, env={}) {
+    // If user defined a folder name use it otherwise use zazu-snippets
+    const folder = (env.hasOwnProperty('folder')) ? env.folder : 'zazu-snippets'
+    // Default is os specific `[home_directory]/zazu-snippets`
+    this.snippetDir = path.join(os.homedir(), folder)
     this.index = {}
     this.console = console
-    this.snippetDir = path.join(this.dir, 'snippets')
     this.indexSnippets()
   }
 
@@ -67,6 +70,6 @@ class Snippets {
 }
 
 var singleton = null
-module.exports = (dir, console) => {
-  return singleton || (singleton = new Snippets(dir, console))
+module.exports = (console, env={}) => {
+  return singleton || (singleton = new Snippets(console, env))
 }

--- a/src/read.js
+++ b/src/read.js
@@ -1,14 +1,10 @@
 module.exports = (pluginContext) => {
   return (query, env = {}) => {
     const { cwd, console } = pluginContext
+    const snippets = require('./lib/snippets')(console, env)
     return new Promise((resolve, reject) => {
-      const snippets = require('./lib/snippets')(cwd, console)
       const results = snippets.search(query)
-      if (!results) {
-        resolve([])
-      } else {
-        resolve(results)
-      }
+      resolve(results ? results : [])
     })
   }
 }

--- a/src/writeSnippet.js
+++ b/src/writeSnippet.js
@@ -1,8 +1,7 @@
 module.exports = (pluginContext) => {
-  const { cwd, console } = pluginContext
-  const snippets = require('./lib/snippets')(cwd, console)
-
   return (name, env = {}) => {
+    const { console } = pluginContext
+    const snippets = require('./lib/snippets')(console, env)
     const content = pluginContext.clipboard.readText()
     snippets.create(name, content)
     return Promise.resolve()


### PR DESCRIPTION
- Configurable snippet folder name
  - Info on setting variables...
    - http://zazuapp.org/documentation/configuration/#plugins
  - Use variable `folder` to change folder or it will default to 'zazu-snippets'
- Make snippet folder in user home directory
  - Snippets by default will be inside...
    - Mac OSX `/Users/<username>/zazu-snippets`
    - Windows 10 `<root>\Users\<username>\zazu-snippets`